### PR TITLE
Introduce some docker best practices

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 * Amazon ECR Docker Credential Helper
 * HashiCorp Terraform
 * AWS CLI
-* Docker Compose
 
 ### Docker-in-Docker
 
@@ -26,7 +25,3 @@ Terraform is a tool for building, changing, and versioning infrastructure safely
 ### 3. AWS Command Line Interface
 
 The AWS Command Line Interface (CLI) is a unified tool to manage your AWS services. Please visit https://aws.amazon.com/cli/?nc1=h_ls for more information.
-
-### 4. Docker Compose
-
-Compose is a tool for defining and running multi-container Docker applications. Please visit https://docs.docker.com/compose/ for more information.


### PR DESCRIPTION
* Use stage builds to minimize size of final docker image
* Shorter and easier curls to get terraform version
* Install aws from bundle
* Remove docker compose as it's not used anymore